### PR TITLE
add '/pages' to the course .mp4 and .webm links so that we see the video on the live website

### DIFF
--- a/pages/blocks/course/course.js
+++ b/pages/blocks/course/course.js
@@ -316,8 +316,8 @@ async function buildPayload(block, payload) {
   const videoSpreadSheetUrl = rows[0].querySelector('a').href;
   payload.videos = await fetchVideos(videoSpreadSheetUrl);
   payload.videos.forEach((video) => {
-    video.mp4 = makeRelative(video.mp4);
-    video.webm = makeRelative(video.webm);
+    video.mp4 = `/pages${makeRelative(video.mp4)}`;
+    video.webm = `/pages${makeRelative(video.webm)}`;
   });
   rows.shift();
   rows.forEach((row, index, array) => {


### PR DESCRIPTION
We needed to add `/pages/` to the start of the relative URL for the videos in the courses block as well, so that they can appear on the live website (https://stock.adobe.com/pages/artisthub/learn/courses/mat-hayward-get-started-with-adobe-stock)

test URL: https://fix-courses-videos--stock--webistry-development.hlx.page/pages/artisthub/learn/courses/mat-hayward-get-started-with-adobe-stock