### PR TITLE
Update artisthub.css to fix a conflict with milo's icon-block

### DIFF
--- a/pages/templates/artisthub/artisthub.css
+++ b/pages/templates/artisthub/artisthub.css
@@ -39,7 +39,7 @@ main h2 {
   line-height: var(--type-heading-xl-lh);
 }
 
-main p {
+main p:not(.icon-area) {
   margin: 0;
   padding-top: 8px;
   padding-bottom: 12px;
@@ -67,11 +67,11 @@ main p.detail-M + h4 {
   padding-top: 8px;
 }
 
-main p:not(.detail-M) + h1,
-main p:not(.detail-M) + h2,
-main p:not(.detail-M) + h3,
-main p:not(.detail-M) + h4
-main p:not(.detail-M) + p.detail-M {
+main p:not(.detail-M):not(.icon-area) + h1,
+main p:not(.detail-M):not(.icon-area) + h2,
+main p:not(.detail-M):not(.icon-area) + h3,
+main p:not(.detail-M):not(.icon-area) + h4
+main p:not(.detail-M):not(.icon-area) + p.detail-M {
   padding-top: var(--block-spacing-m);
 }
 


### PR DESCRIPTION
I noticed a conflict in css that was caused by our `artisthub.css` template file, so I updated the `artisthub.css` file to exclude the block that was being affected.

Test urls:
- [Before](https://main--stock--adobecom.hlx.page/pages/artisthub/community/projects)
   <img width="457" alt="image" src="https://user-images.githubusercontent.com/62023521/213224485-a53a8084-43da-46eb-9f2f-bab7b5694d66.png">

- [After](https://fix-template-conflict--stock--webistry-development.hlx.page/pages/artisthub/community/projects)
   <img width="446" alt="image" src="https://user-images.githubusercontent.com/62023521/213224223-705afe94-6374-4959-95a5-355556ed2993.png">
