### PR TITLE
Fix a typo in image-carousel.js (missing / before "/pages")

### DIFF
--- a/pages/blocks/image-carousel/image-carousel.js
+++ b/pages/blocks/image-carousel/image-carousel.js
@@ -154,8 +154,8 @@ function buildCarousel(imgSlides, block, aspectRatio = '50%') {
   block.appendChild(wrapper);
   const prev = createTag('button', { class: 'image-carousel-arrow image-carousel-previous', 'aria-label': 'Previous slide', type: 'button' });
   const next = createTag('button', { class: 'image-carousel-arrow image-carousel-next', 'aria-label': 'Next slide', type: 'button' });
-  prev.appendChild(createSVG(`pages/blocks/image-carousel/image-carousel.svg`, 'chevron'));
-  next.appendChild(createSVG(`pages/blocks/image-carousel/image-carousel.svg`, 'chevron'));
+  prev.appendChild(createSVG(`/pages/blocks/image-carousel/image-carousel.svg`, 'chevron'));
+  next.appendChild(createSVG(`/pages/blocks/image-carousel/image-carousel.svg`, 'chevron'));
   controls.appendChild(prev);
   controls.appendChild(next);
   imgSlides.forEach((imgSlide, index) => {
@@ -164,7 +164,7 @@ function buildCarousel(imgSlides, block, aspectRatio = '50%') {
     imgSlide.img.tabIndex = 0;
     imgSlide.ariaLabel = `Slide ${index + 1}`;
     const expandButton = createTag('button', { class: 'image-carousel-expand', 'aria-label': 'Open in full screen', type: 'button' });
-    expandButton.appendChild(createSVG(`pages/blocks/image-carousel/image-carousel.svg`, 'expand'));
+    expandButton.appendChild(createSVG(`/pages/blocks/image-carousel/image-carousel.svg`, 'expand'));
     slide.appendChild(expandButton);
     slideswrapper.appendChild(slide);
     const dot = createTag('button', { class: 'image-carousel-dot', 'aria-label': `Slide ${index + 1}`, type: 'button' });
@@ -174,7 +174,7 @@ function buildCarousel(imgSlides, block, aspectRatio = '50%') {
   const lightbox = wrapper.cloneNode(true);
   lightbox.classList.add('image-carousel-lightbox');
   const closeButton = createTag('button', { class: 'image-carousel-close-lightbox', 'aria-label': 'Close full screen', 'type': 'button'  });
-  closeButton.appendChild(createSVG(`pages/blocks/image-carousel/image-carousel.svg`, 'close'));
+  closeButton.appendChild(createSVG(`/pages/blocks/image-carousel/image-carousel.svg`, 'close'));
   lightbox.appendChild(closeButton);
   block.appendChild(lightbox);
   const lightboxThumbnails = lightbox.querySelectorAll('.image-carousel-dot');


### PR DESCRIPTION
Fix a typo in `image-carousel.js` (missing "`/`" before "/pages")
[Before](https://main--stock--adobecom.hlx.page/docs/authoring/blocks/image-carousel) / [After](https://slash-pages-typo-carousel--stock--webistry-development.hlx.page/docs/authoring/blocks/image-carousel)