### PR TITLE
style updates to image rows block

### DIFF
--- a/pages/blocks/image-rows/image-rows.css
+++ b/pages/blocks/image-rows/image-rows.css
@@ -13,12 +13,22 @@ main .image-rows > div:not(.image-rows-caption) > div {
   margin: 0 auto;
 }
 
+main .image-rows > div:not(.image-rows-caption) > div > picture {
+  flex: auto;
+}
+
+main .image-rows > div:not(.image-rows-caption) > div > picture img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
 main .image-rows > div > div > *:not(:last-child):not(em):not(strong):not(p):not(a) {
-  margin-right: 32px;
+  margin-right: 16px;
 }
 
 main .image-rows > div + div:not(.image-rows-caption) {
-  margin-top: 32px;
+  margin-top: 16px;
 }
 
 main .image-rows picture {


### PR DESCRIPTION
Modified the block to make sure the images take the full width in a gallery style

before: https://main--stock--adobecom.hlx.page/drafts/solene/gallery
after: https://image-rows--stock--webistry-development.hlx.page/drafts/solene/gallery

ignore how blurry the images are, they are just placeholders