### PR TITLE
[MWPW-126441] Unblock style-linting by lowercasing all t-shirt sizes in classnames

### DIFF
--- a/pages/blocks/banner/banner.css
+++ b/pages/blocks/banner/banner.css
@@ -24,7 +24,7 @@ main .banner h3 {
   line-height: var(--type-heading-l-lh);
 }
 
-main .banner p:not(.detail-M) {
+main .banner p:not(.detail-m) {
   font-size: var(--type-body-m-size);
   line-height: var(--type-body-m-lh);
 }
@@ -325,7 +325,7 @@ main .banner.large p.button-container {
   order: -2;
 }
 
-main .banner.large .banner-content p.detail-M:first-child {
+main .banner.large .banner-content p.detail-m:first-child {
   padding-top: 16px;
 }
 
@@ -424,7 +424,7 @@ main .banner .banner-content h1:first-child,
 main .banner .banner-content h2:first-child,
 main .banner .banner-content h3:first-child,
 main .banner .banner-content h4:first-child,
-main .banner .banner-content p.detail-M:first-child {
+main .banner .banner-content p.detail-m:first-child {
   padding-top: 0;
 }
 
@@ -483,7 +483,7 @@ main .banner .banner-column.banner-image {
   main .banner .banner-content .banner-column {
     display: block;
   }
-  
+
   main .banner .banner-content .banner-column:nth-child(odd) {
     margin-right: auto;
     margin-left: 0;
@@ -540,7 +540,7 @@ main .banner .banner-column.banner-image {
 
   main .banner.right .banner-column:not(.banner-image) {
     text-align: right;
-  }    
+  }
 
   main .banner.right .banner-column h1,
   main .banner.right .banner-column h2 {
@@ -563,7 +563,7 @@ main .banner .banner-column.banner-image {
     max-height: unset;
   }
 
-  main .banner.large .banner-content p.detail-M:first-child {
+  main .banner.large .banner-content p.detail-m:first-child {
     padding-top: 0;
   }
 
@@ -616,7 +616,7 @@ main .banner .banner-column.banner-image {
     width: 520px;
     max-width: unset;
   }
-  
+
   main .banner .banner-column.banner-image:not(:empty) {
     width: 100%;
   }

--- a/pages/blocks/course/course.js
+++ b/pages/blocks/course/course.js
@@ -41,7 +41,7 @@ async function buildCards(block, payload) {
       const card = createTag('div', { class: 'pf-card' });
       const linkLayer = createTag('a', { class: 'pf-card-container-link' });
       const cardText = createTag('div', { class: 'pf-card-text' });
-      const grayText = createTag('p', { class: 'detail-M', id: handlize(category.subHeading) });
+      const grayText = createTag('p', { class: 'detail-m', id: handlize(category.subHeading) });
 
       const h3 = createTag('div', { class: handlize(link.textContent) });
       h3.textContent = link.textContent;

--- a/pages/blocks/page-feed/page-feed.css
+++ b/pages/blocks/page-feed/page-feed.css
@@ -192,7 +192,7 @@ main .page-feed .pf-card .pf-card-text p {
   color: #747474;
 }
 
-main .page-feed .pf-card .pf-card-text p:not(.detail-M) {
+main .page-feed .pf-card .pf-card-text p:not(.detail-m) {
   font-size: var(--type-body-xs-size);
   line-height: var(--type-body-xs-lh);
 }

--- a/pages/scripts/utils.js
+++ b/pages/scripts/utils.js
@@ -103,7 +103,7 @@ export function transformLinkToAnimation(a) {
 
 export function turnH6intoDetailM(scope = document) {
   scope.querySelectorAll('h6').forEach((h6) => {
-    const p = createTag('p', { class: 'detail-M' }, h6.innerHTML);
+    const p = createTag('p', { class: 'detail-m' }, h6.innerHTML);
     const attrs = h6.attributes;
     for (let i = 0, len = attrs.length; i < len; i += 1) {
       p.setAttribute(attrs[i].name, attrs[i].value);

--- a/pages/templates/artisthub/artisthub.css
+++ b/pages/templates/artisthub/artisthub.css
@@ -49,7 +49,7 @@ main p:empty {
   padding: 0;
 }
 
-main p.detail-M {
+main p.detail-m {
   padding-top: 8px;
   padding-bottom: 8px;
   font-size: 12px;
@@ -60,18 +60,18 @@ main p.detail-M {
   font-weight: bold;
 }
 
-main p.detail-M + h1,
-main p.detail-M + h2,
-main p.detail-M + h3,
-main p.detail-M + h4 {
+main p.detail-m + h1,
+main p.detail-m + h2,
+main p.detail-m + h3,
+main p.detail-m + h4 {
   padding-top: 8px;
 }
 
-main p:not(.detail-M):not(.icon-area) + h1,
-main p:not(.detail-M):not(.icon-area) + h2,
-main p:not(.detail-M):not(.icon-area) + h3,
-main p:not(.detail-M):not(.icon-area) + h4
-main p:not(.detail-M):not(.icon-area) + p.detail-M {
+main p:not(.detail-m):not(.icon-area) + h1,
+main p:not(.detail-m):not(.icon-area) + h2,
+main p:not(.detail-m):not(.icon-area) + h3,
+main p:not(.detail-m):not(.icon-area) + h4,
+main p:not(.detail-m):not(.icon-area) + p.detail-m {
   padding-top: var(--block-spacing-m);
 }
 


### PR DESCRIPTION
* NOTE: This PR relates directly to [#503 in the milo repo](https://github.com/adobecom/milo/pull/503) and SHOULD NOT be merged until the PR in milo is merged and then consumed here.
* Updates all CSS rules to use lowercase t-shirt sizes
* Updates all JS files that set classnames to use lowercase t-shirt sizes
* Should allow us to get a clearer picture of style-linting errors moving forward

Resolves: [MWPW-126441](https://jira.corp.adobe.com/browse/MWPW-126441)

**Test URLs:**
(Note that these should both look the same, but the After view uses lowercase t-shirt size classnames)
- Before: https://main--bacom--adobecom.hlx.page/docs/library/blocks/stats?martech=off
- After: https://ebartholomew-kebab-case-tshirts--bacom--adobecom.hlx.page/docs/library/blocks/stats?martech=off
