### PR TITLE
fix(query-index): allow for multiple values on tags

### DIFF
--- a/helix-query.yaml
+++ b/helix-query.yaml
@@ -19,7 +19,7 @@ indices:
           attribute(el, 'content')
       tags:
         select: head > meta[property="article:tag"]
-        value: |
+        values: |
           attribute(el, 'content')
       publicationDate:
         select: head > meta[name="publication-date"]


### PR DESCRIPTION
Adding support for multiple tags in the query-index file.