### PR TITLE
Update aspect ratio for videos in the custom block "featured-columns"

### DIFF
--- a/pages/blocks/featured-columns/featured-columns.css
+++ b/pages/blocks/featured-columns/featured-columns.css
@@ -155,6 +155,19 @@ main .dark-theme .featured-columns p {
   color: var(--color-white);
 }
 
+/* custom aspect ratio for videos */
+.featured-columns .milo-video,
+.featured-columns .milo-iframe {
+  padding-bottom: 75.2%;
+}
+
+/* hide the black line on the edge of the video */
+.featured-columns .milo-video iframe,
+.featured-columns .milo-iframe iframe {
+  left: -0.5%;
+  width: 101%;
+}
+
 @media screen and (min-width: 800px) {
   /* top variant */
 


### PR DESCRIPTION
*Updates the aspect ratio for videos in the custom block "featured-columns"

*Resolves the issue of the videos having black outlines that are not wanted

*Normalizes the videos across the website to be more uniform

![image](https://user-images.githubusercontent.com/62023521/232856057-64028d4d-5926-478d-97ac-5b4353a48588.png)
![image](https://user-images.githubusercontent.com/62023521/232856134-901cd767-229e-493b-9a42-a0d3d432b123.png)

**Test urls:**
- Before: https://main--stock--adobecom.hlx.page/pages/artisthub/get-inspired/creative-trends
- After: https://aspect-ratio-videos--stock--wbstry.hlx.page/pages/artisthub/get-inspired/creative-trends