### PR TITLE
add edgeIdConfig for stage and prod environments

### DIFF
--- a/pages/scripts/scripts.js
+++ b/pages/scripts/scripts.js
@@ -27,6 +27,8 @@ const CONFIG = {
   // imsClientId: 'college',
   contentRoot: '/pages',
   codeRoot: '/pages',
+  stage: { edgeConfigId: '9a1395f3-a8e1-4287-8625-58c6bddb08f8' },
+  prod: { edgeConfigId: 'da157e66-32ea-47df-bee3-55901c66e46f' },
   locales: {
     '': { ietf: 'en-US', tk: 'hah7vzn.css' },
     br: { ietf: 'pt-BR', tk: 'inq1xob.css' },


### PR DESCRIPTION
Adding the edgeIdConfig parameters provided by Harshavardhan in the franklin-stock channel. This should enable analytics to begin aggregating data in the right place. 

**Test URLs:**
- Before: https://main--stock--adobecom.hlx.page/pages/artisthub/
- After: https://new-edge-config--stock--webistry-development.hlx.page/pages/artisthub/

