### PR TITLE
Add analytics support to the separator block

### DIFF
--- a/pages/blocks/separator/separator.js
+++ b/pages/blocks/separator/separator.js
@@ -1,1 +1,5 @@
-export default function separator(block) {}
+import { decorateBlockAnalytics } from '../../scripts/utils.js';
+
+export default function separator(block) {
+  decorateBlockAnalytics(block);
+}


### PR DESCRIPTION
* I fixed the analytics on the separator block (I had forgot to add it when I did the other blocks)

``` JS
import { decorateBlockAnalytics } from '../../scripts/utils.js';

export default function separator(block) {
  decorateBlockAnalytics(block);
}

```

Test URL: https://analytics-fix--stock--wbstry.hlx.page/pages/artisthub/


Before: 
- https://main--stock--adobecom.hlx.page/pages/artisthub/

After:
- https://analytics-fix--stock--wbstry.hlx.page/pages/artisthub/


<img width="533" alt="image" src="https://user-images.githubusercontent.com/62023521/233176890-888053f1-69e6-4b94-b794-84f3e3e34e88.png">
