### PR TITLE
MWPW-192736: Add check for milolibs query param

### DIFF
--- a/pages/scripts/utils.js
+++ b/pages/scripts/utils.js
@@ -12,6 +12,7 @@ export const [setLibs, getLibs] = (() => {
         libs = prodLibs;
       } else {
         const branch = new URLSearchParams(window.location.search).get('milolibs') || 'main';
+        if (!/^[a-zA-Z0-9_-]+$/.test(branch)) throw new Error('Invalid branch name.');
         if (branch === 'local') {
           libs = 'http://localhost:6456/libs';
         } else if (branch.indexOf('--') > -1) {


### PR DESCRIPTION
Whitelist branch parameter with `/^[a-zA-Z0-9_-]+$/`; throw on any other characters.

## Ticket
https://jira.corp.adobe.com/browse/MWPW-192736

## Test URLs
Before: https://main--stock--adobecom.aem.page/
After: https://MWPW-192736--stock--zagi25.aem.page/

---
_This PR was generated by Claude (Anthropic's Claude Code CLI)._